### PR TITLE
Sprintf to snprintf

### DIFF
--- a/otherfiles/iot_logger_php_server/upload.php
+++ b/otherfiles/iot_logger_php_server/upload.php
@@ -227,7 +227,7 @@
          if(mysqli_query($conn, $sqlQuery))
          {   
             echo "Affected number of configs: " . mysqli_affected_rows($conn);
-            echo "Success";
+            echo "<br>Success";
             echo "<font color='red'> All the devices with related config ids will be updated soon.</font>";
          }
          else

--- a/src/config.h
+++ b/src/config.h
@@ -31,7 +31,7 @@
  }
 
 
- #define MAX_PRINT_BUFFER_SIZE (255)
+ #define MAX_PRINT_BUFFER_SIZE (128)
  static char print_buffer[MAX_PRINT_BUFFER_SIZE];// = {0};
 
  inline char * getPrintBuffer()

--- a/src/config_json_stream_parser.cpp
+++ b/src/config_json_stream_parser.cpp
@@ -21,20 +21,20 @@ Device_config * ConfigListener::getDeviceConfigPtr()
 
 void ConfigListener::whitespace(char c)
 {
-  //sprintf(getPrintBuffer(), "whitespace %c", c);
+  //snprintf(getPrintBuffer(), MAX_PRINT_BUFFER_SIZE, "whitespace %c", c);
   //this->print(getPrintBuffer());
 }
 
 void ConfigListener::startDocument()
 {
-  //sprintf(getPrintBuffer(), "start document");
+  //snprintf(getPrintBuffer(), MAX_PRINT_BUFFER_SIZE, "start document");
   //this->print(getPrintBuffer());
 }
 
 void ConfigListener::key(String key)
 {
   this->current_key_ = key;
-  //sprintf(getPrintBuffer(), "key: %s", key.c_str());
+  //snprintf(getPrintBuffer(), MAX_PRINT_BUFFER_SIZE, "key: %s", key.c_str());
   //this->print(getPrintBuffer());
 }
 
@@ -54,12 +54,12 @@ void ConfigListener::value(String value)
 
   if (index == -1)
   {
-    sprintf(getPrintBuffer(), "cjsp: %d | No valid key received.", __LINE__);
+    snprintf(getPrintBuffer(), MAX_PRINT_BUFFER_SIZE,"cjsp: %d | No valid key received.",   __LINE__);
     this->print(getPrintBuffer());
     return;
   }
 
-  sprintf(getPrintBuffer(), " key: %s value: %s", Device_config_ToString(index), value.c_str());
+  snprintf(getPrintBuffer(), MAX_PRINT_BUFFER_SIZE, " key: %s value: %s", Device_config_ToString(index), value.c_str());
   this->print(getPrintBuffer());
 
   switch (index)
@@ -107,7 +107,7 @@ void ConfigListener::value(String value)
 
     if (value.length() > MAX_VER_STR_SIZE)
     {
-      sprintf(getPrintBuffer(), "cjsp: %d | %s | Possible data truncation.", __LINE__, Device_config_ToString(index));
+      snprintf(getPrintBuffer(), MAX_PRINT_BUFFER_SIZE, "cjsp: %d | %s | Possible data truncation.", __LINE__, Device_config_ToString(index));
       this->print(getPrintBuffer());
     }
   }
@@ -124,7 +124,7 @@ void ConfigListener::value(String value)
 
     if (value.length() > MAX_MINI_STR_SIZE)
     {
-      sprintf(getPrintBuffer(), "cjsp: %d | %s | Possible data truncation.", __LINE__, Device_config_ToString(index));
+      snprintf(getPrintBuffer(), MAX_PRINT_BUFFER_SIZE, "cjsp: %d | %s | Possible data truncation.", __LINE__, Device_config_ToString(index));
       this->print(getPrintBuffer());
     }
   }
@@ -140,7 +140,7 @@ void ConfigListener::value(String value)
 
     if (value.length() > MAX_PATH_SIZE)
     {
-      sprintf(getPrintBuffer(), "cjsp: %d | %s | Possible data truncation.", __LINE__, Device_config_ToString(index));
+      snprintf(getPrintBuffer(), MAX_PRINT_BUFFER_SIZE, "cjsp: %d | %s | Possible data truncation.", __LINE__, Device_config_ToString(index));
       this->print(getPrintBuffer());
     }
   }
@@ -163,7 +163,7 @@ void ConfigListener::value(String value)
 
     if (value.length() > MAX_PATH_SIZE)
     {
-      sprintf(getPrintBuffer(), "cjsp: %d | %s | Possible data truncation.", __LINE__, Device_config_ToString(index));
+      snprintf(getPrintBuffer(), MAX_PRINT_BUFFER_SIZE, "cjsp: %d | %s | Possible data truncation.", __LINE__, Device_config_ToString(index));
       this->print(getPrintBuffer());
     }
   }
@@ -179,7 +179,7 @@ void ConfigListener::value(String value)
 
     if (value.length() > MAX_PATH_SIZE)
     {
-      sprintf(getPrintBuffer(), "cjsp: %d | %s | Possible data truncation.", __LINE__, Device_config_ToString(index));
+      snprintf(getPrintBuffer(), MAX_PRINT_BUFFER_SIZE, "cjsp: %d | %s | Possible data truncation.", __LINE__, Device_config_ToString(index));
       this->print(getPrintBuffer());
     }
   }
@@ -202,7 +202,7 @@ void ConfigListener::value(String value)
 
     if (value.length() > MAX_PATH_SIZE)
     {
-      sprintf(getPrintBuffer(), "cjsp: %d | %s | Possible data truncation.", __LINE__, Device_config_ToString(index));
+      snprintf(getPrintBuffer(), MAX_PRINT_BUFFER_SIZE, "cjsp: %d | %s | Possible data truncation.", __LINE__, Device_config_ToString(index));
       this->print(getPrintBuffer());
     }
   }
@@ -218,7 +218,7 @@ void ConfigListener::value(String value)
 
     if (value.length() > MAX_VER_STR_SIZE)
     {
-      sprintf(getPrintBuffer(), "cjsp: %d | %s | Possible data truncation.", __LINE__, Device_config_ToString(index));
+      snprintf(getPrintBuffer(), MAX_PRINT_BUFFER_SIZE, "cjsp: %d | %s | Possible data truncation.", __LINE__, Device_config_ToString(index));
       this->print(getPrintBuffer());
     }
   }
@@ -234,7 +234,7 @@ void ConfigListener::value(String value)
 
     if (value.length() > MAX_VER_STR_SIZE)
     {
-      sprintf(getPrintBuffer(), "cjsp: %d | %s | Possible data truncation.", __LINE__, Device_config_ToString(index));
+      snprintf(getPrintBuffer(), MAX_PRINT_BUFFER_SIZE, "cjsp: %d | %s | Possible data truncation.", __LINE__, Device_config_ToString(index));
       this->print(getPrintBuffer());
     }
   }
@@ -439,7 +439,7 @@ void ConfigListener::value(String value)
 
     if (value.length() > MAX_PATH_SIZE)
     {
-      sprintf(getPrintBuffer(), "cjsp: %d | %s | Possible data truncation.", __LINE__, Device_config_ToString(index));
+      snprintf(getPrintBuffer(), MAX_PRINT_BUFFER_SIZE, "cjsp: %d | %s | Possible data truncation.", __LINE__, Device_config_ToString(index));
       this->print(getPrintBuffer());
     }
   }
@@ -447,7 +447,7 @@ void ConfigListener::value(String value)
 
   default:
   {
-    sprintf(getPrintBuffer(), "cjsp: %d | (?? %s ??) | Wrong key received.", __LINE__, Device_config_ToString(index));
+    snprintf(getPrintBuffer(), MAX_PRINT_BUFFER_SIZE, "cjsp: %d | (?? %s ??) | Wrong key received.", __LINE__, Device_config_ToString(index));
     this->print(getPrintBuffer());
   }
   }
@@ -460,30 +460,30 @@ void ConfigListener::value(String value)
 
 void ConfigListener::endArray()
 {
-  //sprintf(getPrintBuffer(), "end array. ");
+  //snprintf(getPrintBuffer(), MAX_PRINT_BUFFER_SIZE, "end array. ");
   //this->print(getPrintBuffer());
 }
 
 void ConfigListener::endObject()
 {
-  //sprintf(getPrintBuffer(), "end object. ");
+  //snprintf(getPrintBuffer(), MAX_PRINT_BUFFER_SIZE, "end object. ");
   //this->print(getPrintBuffer());
 }
 
 void ConfigListener::endDocument()
 {
-  sprintf(getPrintBuffer(), "end document. ");
+  snprintf(getPrintBuffer(), MAX_PRINT_BUFFER_SIZE, "end document. ");
   this->print(getPrintBuffer());
 }
 
 void ConfigListener::startArray()
 {
-  //sprintf(getPrintBuffer(), "start array. ");
+  //snprintf(getPrintBuffer(), MAX_PRINT_BUFFER_SIZE, "start array. ");
   //this->print(getPrintBuffer());
 }
 
 void ConfigListener::startObject()
 {
-  //sprintf(getPrintBuffer(), "start object. ");
+  //snprintf(getPrintBuffer(), MAX_PRINT_BUFFER_SIZE, "start object. ");
   //this->print(getPrintBuffer());
 }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -175,14 +175,14 @@ void setup()
 #endif
 
   //Serial.printf_P("status_notify :%d", status_notify);
-  sprintf_P(getPrintBuffer(), "status_notify :%d", status_notify);
+  snprintf_P(getPrintBuffer(), MAX_PRINT_BUFFER_SIZE, "status_notify :%d", status_notify);
   syslog_warn(getPrintBuffer());
  
   if (status_mpu == false)
   {
     notifier_setNotifierState(NOTIFIER_STATES::_0_NOTIFIER_CODE_ERROR);
 
-    sprintf(getPrintBuffer(), "MPU not intialized.");
+    snprintf(getPrintBuffer(), MAX_PRINT_BUFFER_SIZE, "MPU not intialized.");
     Serial.println(getPrintBuffer());
     syslog_warn(getPrintBuffer());
   }
@@ -208,7 +208,7 @@ void loop()
   {
     notifier_setNotifierState(NOTIFIER_STATES::_0_NOTIFIER_CODE_ERROR);
 
-    // sprintf(getPrintBuffer(), "MPU not intialized.");
+    // snprintf(getPrintBuffer(), MAX_PRINT_BUFFER_SIZE, "MPU not intialized.");
     // Serial.println(getPrintBuffer());
     // syslog_warn(getPrintBuffer());
   }
@@ -281,7 +281,7 @@ void loop()
         // check_notification_update_time
         notifier_setNotifierState(NOTIFIER_STATES::_0_NOTIFIER_CODE_ERROR);
       }
-      sprintf(getPrintBuffer(), "No device config found. Synching...");
+      snprintf(getPrintBuffer(), MAX_PRINT_BUFFER_SIZE, "No device config found. Synching...");
       Serial.println(getPrintBuffer());
       syslog_debug(getPrintBuffer());
       has_config_received = setup_php_server();
@@ -310,7 +310,7 @@ void loop()
     {
       delay(0);
 
-      sprintf(getPrintBuffer(), "code updated resetting...");
+      snprintf(getPrintBuffer(), MAX_PRINT_BUFFER_SIZE, "code updated resetting...");
       Serial.println(getPrintBuffer());
       syslog_debug(getPrintBuffer());
 
@@ -412,7 +412,7 @@ void loop()
     {
       notifier_setNotifierState(NOTIFIER_STATES::_0_NOTIFIER_CODE_ERROR);
 
-      sprintf(getPrintBuffer(), "MPU not intialized.");
+      snprintf(getPrintBuffer(), MAX_PRINT_BUFFER_SIZE, "MPU not intialized.");
       Serial.println(getPrintBuffer());
       syslog_warn(getPrintBuffer());
     }

--- a/src/mpu.cpp
+++ b/src/mpu.cpp
@@ -201,7 +201,7 @@ void mpu_loop()
       }
       else
       {
-        sprintf(getPrintBuffer(), "******* |  MPU | buffer empty. ********");
+        snprintf(getPrintBuffer(), MAX_PRINT_BUFFER_SIZE, "******* |  MPU | buffer empty. ********");
         syslog_warn(getPrintBuffer());
         Serial.println(getPrintBuffer());
 
@@ -297,7 +297,7 @@ void mpu_loop()
     if(elapsed_time > (elapsedMillis)(sampling_duration_us/2000.0) )//(1000/5) )
     {
       elapsed_time = 0;
-      sprintf(getPrintBuffer(), "%2.4f, %2.4f, %2.4f, %2.4f, %2.4f", Am_mpu, am_ft / mag_multiflier, acc_fft_magnitude_mpu, acc_fft_magnitude_filtered_mpu, acc_fft_magnitude_double_filtered_mpu);
+      snprintf(getPrintBuffer(), MAX_PRINT_BUFFER_SIZE, "%2.4f, %2.4f, %2.4f, %2.4f, %2.4f", Am_mpu, am_ft / mag_multiflier, acc_fft_magnitude_mpu, acc_fft_magnitude_filtered_mpu, acc_fft_magnitude_double_filtered_mpu);
       sendGraphDate((char*)String(getJsonConfigListenerPtr()->getDeviceConfigPtr()->device_id[0]).c_str(), getPrintBuffer()); 
     }    
 

--- a/src/notifiers.cpp
+++ b/src/notifiers.cpp
@@ -259,7 +259,7 @@ bool notifier_ledNotifierSetup()
 
 	//Serial.println("notify setup");
 	has_notifier_setup = true;
-	sprintf_P(getPrintBuffer(), "status_notify :%d\n", has_notifier_setup);
+	snprintf_P(getPrintBuffer(), MAX_PRINT_BUFFER_SIZE, "status_notify :%d\n", has_notifier_setup);
     DEBUG_LOG(getPrintBuffer());
 
 	
@@ -322,7 +322,7 @@ void setLedNotifierHBState(LED_NOTIFIER_HEARTBEAT_STATE _led_bh_state)
  	}
 	last_state = _led_bh_state;	
 
-	sprintf_P(getPrintBuffer(), "hb notify state :%d\n", led_white_breahe_state);
+	snprintf_P(getPrintBuffer(), MAX_PRINT_BUFFER_SIZE, "hb notify state :%d\n", led_white_breahe_state);
     DEBUG_LOG(getPrintBuffer());
 
 /*
@@ -362,12 +362,12 @@ LED_WHITE_BREATHE_STATE__OFF, // LED OFF
 		//ledState(LED_ID_WHITE, 0.0);  
 		ledDetach(LED_ID_WHITE, false);
 		led_white_breahe_state = (LED_WHITE_BREATHE_STATE)_led_bh_state;
-		sprintf_P(getPrintBuffer(), "hb notify state :%d\n", led_white_breahe_state);
+		snprintf_P(getPrintBuffer(), MAX_PRINT_BUFFER_SIZE, "hb notify state :%d\n", led_white_breahe_state);
     	DEBUG_LOG(getPrintBuffer());
 	}
 	else
 	{
-		sprintf_P(getPrintBuffer(), "Notifier: LED_WHITE_BREATHE_STATE__INVALID at %d\n", __LINE__);
+		snprintf_P(getPrintBuffer(), MAX_PRINT_BUFFER_SIZE, "Notifier: LED_WHITE_BREATHE_STATE__INVALID at %d\n", __LINE__);
 		Serial.printf(getPrintBuffer());
 		//syslog_warn(getPrintBuffer());
 	} 
@@ -392,7 +392,7 @@ void setLedNotofierCodeBurnState(LED_NOTIFIER_CODE_BURN_STATE _state)
  	}
 	last_state = _state;	
 
-	sprintf_P(getPrintBuffer(), "burn notify state :%d\n", _state);
+	snprintf_P(getPrintBuffer(), MAX_PRINT_BUFFER_SIZE, "burn notify state :%d\n", _state);
     DEBUG_LOG(getPrintBuffer());
 
 	switch (_state)
@@ -441,7 +441,7 @@ void setLedNotifierWIFIState(LED_NOTIFIER_WIFI_STATE _state)
  	}
 	last_state = _state;
 
-	sprintf_P(getPrintBuffer(), "wifi notify state :%d\n", _state);
+	snprintf_P(getPrintBuffer(), MAX_PRINT_BUFFER_SIZE, "wifi notify state :%d\n", _state);
     DEBUG_LOG(getPrintBuffer());
 
 	switch (_state)
@@ -494,7 +494,7 @@ void setLedNotifierServerState(LED_NOTIFIER_SERVER_STATE _state)
 	last_state = _state;
 
 
-	sprintf_P(getPrintBuffer(), "server notify state :%d\n", _state);
+	snprintf_P(getPrintBuffer(), MAX_PRINT_BUFFER_SIZE, "server notify state :%d\n", _state);
     DEBUG_LOG(getPrintBuffer());
 
 	switch (_state)
@@ -553,7 +553,7 @@ void setLedNotifierSensorState(LED_NOTIFIER_SENSOR_STATE _state)
 	last_state = _state;
 
 
-	sprintf_P(getPrintBuffer(), "sense notify state :%d\n", _state);
+	snprintf_P(getPrintBuffer(), MAX_PRINT_BUFFER_SIZE, "sense notify state :%d\n", _state);
     DEBUG_LOG(getPrintBuffer());
 
 	switch (_state)
@@ -627,12 +627,12 @@ void notifier_setNotifierState(NOTIFIER_STATES _state)
  
 	if(false == has_notifier_setup)
 	{
-		sprintf_P(getPrintBuffer(), "warn | notify state :has_notifier_setup: %d\n", has_notifier_setup);
+		snprintf_P(getPrintBuffer(), MAX_PRINT_BUFFER_SIZE, "warn | notify state :has_notifier_setup: %d\n", has_notifier_setup);
     	DEBUG_LOG(getPrintBuffer());
 		return;
 	}	
 
-	sprintf_P(getPrintBuffer(), "notify state :%d\n", _state);
+	snprintf_P(getPrintBuffer(), MAX_PRINT_BUFFER_SIZE, "notify state :%d\n", _state);
     DEBUG_LOG(getPrintBuffer());
 
 

--- a/src/ota.cpp
+++ b/src/ota.cpp
@@ -71,7 +71,7 @@ void setup_OTA()
 
     // NOTE: if updating SPIFFS this would be the place to unmount SPIFFS using SPIFFS.end()
     //Serial.println("Start updating ?" + type);
-    sprintf(getPrintBuffer(), "Start local OTA update ... ?");
+    snprintf(getPrintBuffer(), MAX_PRINT_BUFFER_SIZE, "Start local OTA update ... ?");
     notifier_setNotifierState(NOTIFIER_STATES::_0_NOTIFIER_LOCAL_CODE_BURN_STARTED);
     //Serial.println();
     Serial.println(getPrintBuffer());
@@ -80,7 +80,7 @@ void setup_OTA()
   ArduinoOTA.onEnd([]() {
     isInProgramMode = false;
     //Serial.println("\nEnd");
-    sprintf(getPrintBuffer(), "Ended local OTA update.");
+    snprintf(getPrintBuffer(), MAX_PRINT_BUFFER_SIZE, "Ended local OTA update.");
     //Serial.println();
     Serial.println(getPrintBuffer());
     syslog_debug(getPrintBuffer());
@@ -88,7 +88,7 @@ void setup_OTA()
   ArduinoOTA.onProgress([](unsigned int progress, unsigned int total) {
     isInProgramMode = true;
     notifier_ledNotifierLoop();
-    sprintf(getPrintBuffer(), "Progress local OTA: %u%%", (progress / (total / 100)));
+    snprintf(getPrintBuffer(), MAX_PRINT_BUFFER_SIZE, "Progress local OTA: %u%%", (progress / (total / 100)));
     //Serial.println();
     Serial.println(getPrintBuffer());
     syslog_debug(getPrintBuffer());
@@ -98,28 +98,28 @@ void setup_OTA()
     notifier_setNotifierState(NOTIFIER_STATES::_0_NOTIFIER_CODE_ERROR);
 
     isInProgramMode = false;
-    sprintf(getPrintBuffer(), "Error[%u]: ", error);
+    snprintf(getPrintBuffer(), MAX_PRINT_BUFFER_SIZE, "Error[%u]: ", error);
     //Serial.println();
     Serial.println(getPrintBuffer());
     syslog_debug(getPrintBuffer());
     //Serial.printf("Error[%u]: ", error);
     if (error == OTA_AUTH_ERROR)
-      sprintf(getPrintBuffer(), "Auth Failed");
+      snprintf(getPrintBuffer(), MAX_PRINT_BUFFER_SIZE, "Auth Failed");
     else if (error == OTA_BEGIN_ERROR)
-      sprintf(getPrintBuffer(), "Begin Failed");
+      snprintf(getPrintBuffer(), MAX_PRINT_BUFFER_SIZE, "Begin Failed");
     else if (error == OTA_CONNECT_ERROR)
-      sprintf(getPrintBuffer(), "Connect Failed");
+      snprintf(getPrintBuffer(), MAX_PRINT_BUFFER_SIZE, "Connect Failed");
     else if (error == OTA_RECEIVE_ERROR)
-      sprintf(getPrintBuffer(), "Receive Failed");
+      snprintf(getPrintBuffer(), MAX_PRINT_BUFFER_SIZE, "Receive Failed");
     else if (error == OTA_END_ERROR)
-      sprintf(getPrintBuffer(), "End Failed");
+      snprintf(getPrintBuffer(), MAX_PRINT_BUFFER_SIZE, "End Failed");
 
     Serial.println(getPrintBuffer());
     syslog_debug(getPrintBuffer());
   });
   ArduinoOTA.begin();
   isSetupOK = true;
-  sprintf(getPrintBuffer(), "Ready | IP address: %s | In ubutnu please run following command to configure firewall => $ sudo ufw allow from %s", WiFi.localIP().toString().c_str(), WiFi.localIP().toString().c_str());
+  snprintf(getPrintBuffer(), MAX_PRINT_BUFFER_SIZE, "Ready | IP address: %s | In ubutnu please run following command to configure firewall => $ sudo ufw allow from %s", WiFi.localIP().toString().c_str(), WiFi.localIP().toString().c_str());
   //Serial.println();
   Serial.println(getPrintBuffer());
   syslog_debug(getPrintBuffer());

--- a/src/process_config_firmwre_update.cpp
+++ b/src/process_config_firmwre_update.cpp
@@ -33,7 +33,7 @@ bool updateFirmware(char*_version_firmware)
     bool status = false;
     String path_to_firmware = String(php_upgrade_server_file_target) + String("/") +String(_version_firmware)+".bin";
 
-    sprintf(getPrintBuffer(), "Getting firmware: %s", path_to_firmware.c_str());
+    snprintf(getPrintBuffer(), MAX_PRINT_BUFFER_SIZE, "Getting firmware: %s", path_to_firmware.c_str());
     Serial.println(getPrintBuffer());
     syslog_debug(getPrintBuffer());
 
@@ -53,11 +53,11 @@ bool updateFirmware(char*_version_firmware)
     switch (ret)
     {
     case HTTP_UPDATE_FAILED:
-        sprintf(getPrintBuffer(), "%s", path_to_firmware.c_str());
+        snprintf(getPrintBuffer(), MAX_PRINT_BUFFER_SIZE, "%s", path_to_firmware.c_str());
         Serial.println(getPrintBuffer());
         syslog_debug(getPrintBuffer());
 
-        sprintf(getPrintBuffer(), "HTTP_UPDATE_FAILD Error (%d): %s", ESPhttpUpdate.getLastError(), ESPhttpUpdate.getLastErrorString().c_str());
+        snprintf(getPrintBuffer(), MAX_PRINT_BUFFER_SIZE, "HTTP_UPDATE_FAILD Error (%d): %s", ESPhttpUpdate.getLastError(), ESPhttpUpdate.getLastErrorString().c_str());
         Serial.println(getPrintBuffer());
         syslog_debug(getPrintBuffer());
 
@@ -72,7 +72,7 @@ bool updateFirmware(char*_version_firmware)
 
         status = true;
 
-        sprintf(getPrintBuffer(), "[update] Update ok. - time spent on update %d", time_spent_to_update);
+        snprintf(getPrintBuffer(), MAX_PRINT_BUFFER_SIZE, "[update] Update ok. - time spent on update %d", time_spent_to_update);
 
         Serial.println(getPrintBuffer()); // may not called we reboot the ESP
         syslog_debug(getPrintBuffer());
@@ -95,7 +95,7 @@ bool processConfig()
 
     if (FW_UPDATE_AVAILABLE == config->whether_update_available[0])
     {
-        sprintf(getPrintBuffer(), "code update in progress (can take upto 5 minutes max)...");
+        snprintf(getPrintBuffer(), MAX_PRINT_BUFFER_SIZE, "code update in progress (can take upto 5 minutes max)...");
         Serial.println(getPrintBuffer());
         syslog_debug(getPrintBuffer());
         delay(10);


### PR DESCRIPTION
Assumption
the sprintf was crashing the esp8266
for the variable 
static char print_buffer[MAX_PRINT_BUFFER_SIZE];

Used 
https://github.com/luffykesh/EspExceptionDecoder-CLI
to stack decode

Probable stack places
*0x4020d49d    *0x402061ea    *0x4020430c    *0x40215438    *0x40215860    *0x40204381    *0x40204486    *0x4020162e    *0x402044c4    *0x40201c0e    *0x4021b60c    *0x402112b7    *0x402029fc    *0x4021b5e4    *0x4021b5e4    *0x402134bc    *0x40101179

on of them was the only user code variable print_buffer

Seems working fine now.

To recreate, upload a new binary and let it sync for config. If it fails as waiting for header it crases.

path/xtensa-lx106-elf-readelf firmware.elf -a 


